### PR TITLE
v0.2.3: Use a dummy image by Lorem Picsum instead of capture.heartrails.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Here is guide of attributes:
 * sitename (optional): Sitename of the page.
 * description (optional): Description or summary of the page.
 * url (mandatory): URL of the page.
-* imgurl (optional): Thumbnail image of the page. If this is omitted, the capture of the page will be shown.
+* imgurl (optional): Thumbnail image of the page. If this is omitted, a dummy image by [Lorem Picsum](https://picsum.photos/) will be shown.
 
 
 Future work

--- a/tera-share.php
+++ b/tera-share.php
@@ -3,7 +3,7 @@
 Plugin Name: Tera Share
 Plugin URI: https://github.com/kotarot/tera-share
 Description: WP plugin that inserts blog-card-like links in articles.
-Version: 0.2.2
+Version: 0.2.3
 Author: Kotaro Terada
 Author URI: https://www.terabo.net/
 License: Apache License 2.0
@@ -54,7 +54,7 @@ function terashare_func($atts) {
     if ($imgurl) {
         $html .= '<img class="terashare-thumbnail" align="left" border="0" src="' . $imgurl . '" alt="Thumbnail of ' . $title . '" /></a>';
     } else {
-        $html .= '<img class="terashare-thumbnail" align="left" border="0" src="http://capture.heartrails.com/?' . $url . '" alt="Thumbnail of  ' . $title . '" /></a>';
+        $html .= '<img class="terachare-thumbnail" align="left" border="0" src="https://picsum.photos/160/120/?random" alt="Sample image by Lorem Picsum" /></a>';
     }
     $html .= '<a href="' . $url . '" target="_blank" class="terashare-title"><span class="terashare-title">' . $title . '</span></a>';
     if ($sitename) {


### PR DESCRIPTION
v0.2.3: Use a dummy image by Lorem Picsum instead of capture.heartrails.com